### PR TITLE
🔒 construct: lock it down with TokenAuthorizer

### DIFF
--- a/apps/infrastructure/test/__snapshots__/turbo-remote-cache.test.ts.snap
+++ b/apps/infrastructure/test/__snapshots__/turbo-remote-cache.test.ts.snap
@@ -265,6 +265,67 @@ exports[`TurboRemoteCacheStack snapshot test 1`] = `
       },
       "Type": "AWS::ApiGateway::Model",
     },
+    "TurboRemoteCacheAPIGatewayTokenAuthorizerE21E3B0F": {
+      "Properties": {
+        "AuthorizerResultTtlInSeconds": 3600,
+        "AuthorizerUri": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Fn::Select": [
+                  1,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "TurboRemoteCacheLambdaFunctionsTokenAuthorizerFunction06F32FD1",
+                          "Arn",
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              ":apigateway:",
+              {
+                "Fn::Select": [
+                  3,
+                  {
+                    "Fn::Split": [
+                      ":",
+                      {
+                        "Fn::GetAtt": [
+                          "TurboRemoteCacheLambdaFunctionsTokenAuthorizerFunction06F32FD1",
+                          "Arn",
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "TurboRemoteCacheLambdaFunctionsTokenAuthorizerFunction06F32FD1",
+                  "Arn",
+                ],
+              },
+              "/invocations",
+            ],
+          ],
+        },
+        "IdentitySource": "method.request.header.Authorization",
+        "Name": "TurboRemoteCacheStackTurboRemoteCacheAPIGatewayTokenAuthorizer96669B3D",
+        "RestApiId": {
+          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
+        },
+        "Type": "TOKEN",
+      },
+      "Type": "AWS::ApiGateway::Authorizer",
+    },
     "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413": {
       "Properties": {
         "BinaryMediaTypes": [
@@ -351,20 +412,12 @@ exports[`TurboRemoteCacheStack snapshot test 1`] = `
       },
       "Type": "AWS::ApiGateway::BasePathMapping",
     },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiDeploymentA3F8C9A582f488429fb6628155c17470a6e1057e": {
+    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiDeploymentA3F8C9A5d49a9c3039eb1d9b1819ffc1af35ed2a": {
       "DependsOn": [
         "TurboRemoteCacheAPIGatewayArtifactQueryModel5321348F",
         "TurboRemoteCacheAPIGatewayPutArtifactResponseModel270400F2",
         "TurboRemoteCacheAPIGatewayRecordEventsModel6C9AF718",
         "TurboRemoteCacheAPIGatewayStatusResponseModelB501FDFE",
-        "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturborepoBA4106BF",
-        "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturboreposuccessGET127C2075",
-        "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturboreposuccess0C278883",
-        "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturborepotokenGETC2E32EEA",
-        "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturborepotokenFCF0C102",
-        "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv2558F4A9F",
-        "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv2userGETFB8012C9",
-        "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv2user307EB411",
         "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv8artifactshashGETE7538659",
         "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv8artifactshashHEAD1C8B6AC1",
         "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv8artifactshashPUT17E3E309",
@@ -414,7 +467,7 @@ exports[`TurboRemoteCacheStack snapshot test 1`] = `
           "Format": "{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","user":"$context.identity.user","caller":"$context.identity.caller","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength"}",
         },
         "DeploymentId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiDeploymentA3F8C9A582f488429fb6628155c17470a6e1057e",
+          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiDeploymentA3F8C9A5d49a9c3039eb1d9b1819ffc1af35ed2a",
         },
         "DocumentationVersion": "8.0.0",
         "MethodSettings": [
@@ -432,429 +485,6 @@ exports[`TurboRemoteCacheStack snapshot test 1`] = `
         "TracingEnabled": true,
       },
       "Type": "AWS::ApiGateway::Stage",
-    },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturborepoBA4106BF": {
-      "Properties": {
-        "ParentId": {
-          "Fn::GetAtt": [
-            "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-            "RootResourceId",
-          ],
-        },
-        "PathPart": "turborepo",
-        "RestApiId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturboreposuccess0C278883": {
-      "Properties": {
-        "ParentId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturborepoBA4106BF",
-        },
-        "PathPart": "success",
-        "RestApiId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturboreposuccessGET127C2075": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                {
-                  "Fn::GetAtt": [
-                    "TurboRemoteCacheLambdaFunctionsLoginSuccessFunction6FBFB22F",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "OperationName": "loginSuccess",
-        "ResourceId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturboreposuccess0C278883",
-        },
-        "RestApiId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturboreposuccessGETApiPermissionTestTurboRemoteCacheStackTurboRemoteCacheAPIGatewayTurboRemoteCacheApiBBF453B6GETturboreposuccess0A1C68C9": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "TurboRemoteCacheLambdaFunctionsLoginSuccessFunction6FBFB22F",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-              },
-              "/test-invoke-stage/GET/turborepo/success",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturboreposuccessGETApiPermissionTurboRemoteCacheStackTurboRemoteCacheAPIGatewayTurboRemoteCacheApiBBF453B6GETturboreposuccess8A5ED094": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "TurboRemoteCacheLambdaFunctionsLoginSuccessFunction6FBFB22F",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-              },
-              "/",
-              {
-                "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiDeploymentStageprod6F04E129",
-              },
-              "/GET/turborepo/success",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturborepotokenFCF0C102": {
-      "Properties": {
-        "ParentId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturborepoBA4106BF",
-        },
-        "PathPart": "token",
-        "RestApiId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturborepotokenGETApiPermissionTestTurboRemoteCacheStackTurboRemoteCacheAPIGatewayTurboRemoteCacheApiBBF453B6GETturborepotokenC8A69CDD": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "TurboRemoteCacheLambdaFunctionsInitiateLoginFunctionFD31A03C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-              },
-              "/test-invoke-stage/GET/turborepo/token",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturborepotokenGETApiPermissionTurboRemoteCacheStackTurboRemoteCacheAPIGatewayTurboRemoteCacheApiBBF453B6GETturborepotoken213D6456": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "TurboRemoteCacheLambdaFunctionsInitiateLoginFunctionFD31A03C",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-              },
-              "/",
-              {
-                "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiDeploymentStageprod6F04E129",
-              },
-              "/GET/turborepo/token",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturborepotokenGETC2E32EEA": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                {
-                  "Fn::GetAtt": [
-                    "TurboRemoteCacheLambdaFunctionsInitiateLoginFunctionFD31A03C",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "OperationName": "initiateLogin",
-        "ResourceId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiturborepotokenFCF0C102",
-        },
-        "RestApiId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv2558F4A9F": {
-      "Properties": {
-        "ParentId": {
-          "Fn::GetAtt": [
-            "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-            "RootResourceId",
-          ],
-        },
-        "PathPart": "v2",
-        "RestApiId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv2user307EB411": {
-      "Properties": {
-        "ParentId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv2558F4A9F",
-        },
-        "PathPart": "user",
-        "RestApiId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv2userGETApiPermissionTestTurboRemoteCacheStackTurboRemoteCacheAPIGatewayTurboRemoteCacheApiBBF453B6GETv2user37389F15": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "TurboRemoteCacheLambdaFunctionsGetUserInfoFunction68482AC5",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-              },
-              "/test-invoke-stage/GET/v2/user",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv2userGETApiPermissionTurboRemoteCacheStackTurboRemoteCacheAPIGatewayTurboRemoteCacheApiBBF453B6GETv2user0193C368": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "TurboRemoteCacheLambdaFunctionsGetUserInfoFunction68482AC5",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              {
-                "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-              },
-              "/",
-              {
-                "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiDeploymentStageprod6F04E129",
-              },
-              "/GET/v2/user",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv2userGETFB8012C9": {
-      "Properties": {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                {
-                  "Fn::GetAtt": [
-                    "TurboRemoteCacheLambdaFunctionsGetUserInfoFunction68482AC5",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "OperationName": "getUserInfo",
-        "ResourceId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv2user307EB411",
-        },
-        "RestApiId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
     },
     "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv8D60AE5A1": {
       "Properties": {
@@ -885,7 +515,10 @@ exports[`TurboRemoteCacheStack snapshot test 1`] = `
     },
     "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv8artifactsPOST25582727": {
       "Properties": {
-        "AuthorizationType": "NONE",
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": {
+          "Ref": "TurboRemoteCacheAPIGatewayTokenAuthorizerE21E3B0F",
+        },
         "HttpMethod": "POST",
         "Integration": {
           "IntegrationHttpMethod": "POST",
@@ -1026,7 +659,10 @@ exports[`TurboRemoteCacheStack snapshot test 1`] = `
     },
     "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv8artifactseventsPOST3BFBEAD1": {
       "Properties": {
-        "AuthorizationType": "NONE",
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": {
+          "Ref": "TurboRemoteCacheAPIGatewayTokenAuthorizerE21E3B0F",
+        },
         "HttpMethod": "POST",
         "Integration": {
           "IntegrationHttpMethod": "POST",
@@ -1171,7 +807,10 @@ exports[`TurboRemoteCacheStack snapshot test 1`] = `
     },
     "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv8artifactshashGETE7538659": {
       "Properties": {
-        "AuthorizationType": "NONE",
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": {
+          "Ref": "TurboRemoteCacheAPIGatewayTokenAuthorizerE21E3B0F",
+        },
         "HttpMethod": "GET",
         "Integration": {
           "Credentials": {
@@ -1264,7 +903,10 @@ exports[`TurboRemoteCacheStack snapshot test 1`] = `
     },
     "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv8artifactshashHEAD1C8B6AC1": {
       "Properties": {
-        "AuthorizationType": "NONE",
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": {
+          "Ref": "TurboRemoteCacheAPIGatewayTokenAuthorizerE21E3B0F",
+        },
         "HttpMethod": "HEAD",
         "Integration": {
           "Credentials": {
@@ -1343,7 +985,10 @@ exports[`TurboRemoteCacheStack snapshot test 1`] = `
     },
     "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv8artifactshashPUT17E3E309": {
       "Properties": {
-        "AuthorizationType": "NONE",
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": {
+          "Ref": "TurboRemoteCacheAPIGatewayTokenAuthorizerE21E3B0F",
+        },
         "HttpMethod": "PUT",
         "Integration": {
           "Credentials": {
@@ -1530,7 +1175,10 @@ exports[`TurboRemoteCacheStack snapshot test 1`] = `
     },
     "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiv8artifactsstatusGETB3D31BB5": {
       "Properties": {
-        "AuthorizationType": "NONE",
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": {
+          "Ref": "TurboRemoteCacheAPIGatewayTokenAuthorizerE21E3B0F",
+        },
         "HttpMethod": "GET",
         "Integration": {
           "IntegrationHttpMethod": "POST",
@@ -1578,48 +1226,6 @@ exports[`TurboRemoteCacheStack snapshot test 1`] = `
         },
       },
       "Type": "AWS::ApiGateway::Method",
-    },
-    "TurboRemoteCacheAPIGatewayTurborepoInitiateLoginDocumentationPartBFB2DF4C": {
-      "Properties": {
-        "Location": {
-          "Method": "GET",
-          "Path": "/v8/turborepo/token",
-          "Type": "METHOD",
-        },
-        "Properties": "{"description":"Initiates a login process for Turborepo.","summary":"Initiate login","tags":["login"]}",
-        "RestApiId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-        },
-      },
-      "Type": "AWS::ApiGateway::DocumentationPart",
-    },
-    "TurboRemoteCacheAPIGatewayTurborepoLoginSuccessDocumentationPartBCB50D06": {
-      "Properties": {
-        "Location": {
-          "Method": "GET",
-          "Path": "/v8/turborepo/success",
-          "Type": "METHOD",
-        },
-        "Properties": "{"description":"Handles the success of a login process for Turborepo.","summary":"Login success","tags":["login"]}",
-        "RestApiId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-        },
-      },
-      "Type": "AWS::ApiGateway::DocumentationPart",
-    },
-    "TurboRemoteCacheAPIGatewayTurborepoUserInfoDocumentationPartB3E077C9": {
-      "Properties": {
-        "Location": {
-          "Method": "GET",
-          "Path": "/v2/user",
-          "Type": "METHOD",
-        },
-        "Properties": "{"description":"Retrieves information about the authenticated user.","summary":"Get user info","tags":["login"]}",
-        "RestApiId": {
-          "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
-        },
-      },
-      "Type": "AWS::ApiGateway::DocumentationPart",
     },
     "TurboRemoteCacheArtifactsBucketF0A2E6E7": {
       "DeletionPolicy": "Retain",
@@ -1813,178 +1419,6 @@ exports[`TurboRemoteCacheStack snapshot test 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "TurboRemoteCacheLambdaFunctionsGetUserInfoFunction68482AC5": {
-      "DependsOn": [
-        "TurboRemoteCacheLambdaFunctionsGetUserInfoFunctionServiceRole13E3DEB5",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "8e14f93aa5f1877625e8bef0cb76c9e8813cd5c29a32327ec1108aa3a317b449.zip",
-        },
-        "FunctionName": "turbo-remote-cache-get-user-info",
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "TurboRemoteCacheLambdaFunctionsGetUserInfoFunctionServiceRole13E3DEB5",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs20.x",
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "TurboRemoteCacheLambdaFunctionsGetUserInfoFunctionServiceRole13E3DEB5": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "TurboRemoteCacheLambdaFunctionsInitiateLoginFunctionFD31A03C": {
-      "DependsOn": [
-        "TurboRemoteCacheLambdaFunctionsInitiateLoginFunctionServiceRoleE032D571",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "6c10a3408d4b564d3def44310ad190bc8427cd875e04b1dfc54810dc1d099844.zip",
-        },
-        "Environment": {
-          "Variables": {
-            "TURBO_TOKEN": "gmuSGqofxxiJti9Rp/cMtoQZogCLRKp51AWo8Gp65Cg=",
-          },
-        },
-        "FunctionName": "turbo-remote-cache-initiate-login",
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "TurboRemoteCacheLambdaFunctionsInitiateLoginFunctionServiceRoleE032D571",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs20.x",
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "TurboRemoteCacheLambdaFunctionsInitiateLoginFunctionServiceRoleE032D571": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "TurboRemoteCacheLambdaFunctionsLoginSuccessFunction6FBFB22F": {
-      "DependsOn": [
-        "TurboRemoteCacheLambdaFunctionsLoginSuccessFunctionServiceRoleFE578867",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "805b64f59eb7338dbe503bfbcbb05038c628bf9be4e18c838b80da7abc1d7e96.zip",
-        },
-        "Environment": {
-          "Variables": {
-            "TURBO_TOKEN": "gmuSGqofxxiJti9Rp/cMtoQZogCLRKp51AWo8Gp65Cg=",
-          },
-        },
-        "FunctionName": "turbo-remote-cache-login-success",
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "TurboRemoteCacheLambdaFunctionsLoginSuccessFunctionServiceRoleFE578867",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs20.x",
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "TurboRemoteCacheLambdaFunctionsLoginSuccessFunctionServiceRoleFE578867": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
     },
     "TurboRemoteCacheLambdaFunctionsRecordEventsFunction35F02F6E": {
       "DependsOn": [
@@ -2236,6 +1670,105 @@ exports[`TurboRemoteCacheStack snapshot test 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "TurboRemoteCacheLambdaFunctionsTokenAuthorizerFunction06F32FD1": {
+      "DependsOn": [
+        "TurboRemoteCacheLambdaFunctionsTokenAuthorizerFunctionServiceRoleCE71DDCF",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "8b700c9b1fc222cb5b0d71408fbe9938f46017c169a9a40bb4078c32b461a8e9.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "TURBO_TOKEN": "gmuSGqofxxiJti9Rp/cMtoQZogCLRKp51AWo8Gp65Cg=",
+          },
+        },
+        "FunctionName": "turbo-remote-cache-token-authorizer",
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "TurboRemoteCacheLambdaFunctionsTokenAuthorizerFunctionServiceRoleCE71DDCF",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "TurboRemoteCacheLambdaFunctionsTokenAuthorizerFunctionServiceRoleCE71DDCF": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TurboRemoteCacheLambdaFunctionsTokenAuthorizerFunctionTurboRemoteCacheStackTurboRemoteCacheAPIGatewayTokenAuthorizer96669B3DPermissions5AC5919D": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "TurboRemoteCacheLambdaFunctionsTokenAuthorizerFunction06F32FD1",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "TurboRemoteCacheAPIGatewayTurboRemoteCacheApiACECE413",
+              },
+              "/authorizers/",
+              {
+                "Ref": "TurboRemoteCacheAPIGatewayTokenAuthorizerE21E3B0F",
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "TurboRemoteCacheS3CredentialsRole957963F3": {
       "Properties": {

--- a/packages/construct/README.md
+++ b/packages/construct/README.md
@@ -48,7 +48,15 @@ export class TurboRemoteCacheStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
+    // load TURBO_TOKEN from .env file
+    dotenv.config({ path: path.join(__dirname, '..', '.env') });
+
+    if (!process.env.TURBO_TOKEN) {
+      throw new Error('TURBO_TOKEN is not set');
+    }
+
     new TurboRemoteCache(this, 'TurboRemoteCache', {
+      turboToken: process.env.TURBO_TOKEN,
       apiProps: {
         // optional domain name options for using a custom domain with API Gateway
         domainName: {

--- a/packages/construct/lambda/src/token-authorizer/index.ts
+++ b/packages/construct/lambda/src/token-authorizer/index.ts
@@ -1,0 +1,25 @@
+import { APIGatewayTokenAuthorizerHandler } from "aws-lambda";
+
+export const handler: APIGatewayTokenAuthorizerHandler = async (event) => {
+  let token = event.authorizationToken;
+  if (token.startsWith('Bearer ')) {
+    token = token.substring(7);
+  }
+  const turboToken = process.env.TURBO_TOKEN;
+
+  if (token === turboToken) {
+    return {
+      principalId: 'user',
+      policyDocument: {
+        Version: '2012-10-17',
+        Statement: [{
+          Action: 'execute-api:Invoke',
+          Effect: 'Allow',
+          Resource: event.methodArn
+        }]
+      }
+    };
+  } else {
+    throw new Error('Unauthorized');
+  }
+};

--- a/packages/construct/src/api.ts
+++ b/packages/construct/src/api.ts
@@ -21,6 +21,12 @@ export class APIGateway extends Construct {
     super(scope, id);
     const logGroup = logs.LogGroup.fromLogGroupName(this, 'LogGroup', '/aws/apigateway/turbo-remote-cache-api');
 
+    const tokenAuthorizer = new apigateway.TokenAuthorizer(this, 'TokenAuthorizer', {
+      handler: props.lambdaFunctions.tokenAuthorizerFunction,
+      resultsCacheTtl: cdk.Duration.minutes(60),
+      identitySource: 'method.request.header.Authorization',
+    });
+
     const api = new apigateway.RestApi(this, 'TurboRemoteCacheApi', {
       restApiName: 'Turborepo Remote Cache API',
       description: 'Turborepo is an intelligent build system optimized for JavaScript and TypeScript codebases.',
@@ -34,6 +40,10 @@ export class APIGateway extends Construct {
         tracingEnabled: true,
       },
       binaryMediaTypes: ['application/octet-stream'],
+      defaultMethodOptions: {
+        authorizationType: apigateway.AuthorizationType.CUSTOM,
+        authorizer: tokenAuthorizer,
+      },
       ...props.apiProps,
     });
 

--- a/packages/construct/src/api.ts
+++ b/packages/construct/src/api.ts
@@ -200,76 +200,77 @@ export class APIGateway extends Construct {
     });
 
     // turbo login
-    const turborepoResource = api.root.addResource('turborepo');
-    const tokenResource = turborepoResource.addResource('token');
+    // TODO: implement turbo login for third party JWTs
+    // const turborepoResource = api.root.addResource('turborepo');
+    // const tokenResource = turborepoResource.addResource('token');
 
-    // GET /v8/turborepo/token
-    tokenResource.addMethod('GET', new apigateway.LambdaIntegration(props.lambdaFunctions.initiateLoginFunction), {
-      operationName: 'initiateLogin',
-    });
+    // // GET /v8/turborepo/token
+    // tokenResource.addMethod('GET', new apigateway.LambdaIntegration(props.lambdaFunctions.initiateLoginFunction), {
+    //   operationName: 'initiateLogin',
+    // });
 
-    const initiateLoginDocumentationPart = {
-      description: 'Initiates a login process for Turborepo.',
-      summary: 'Initiate login',
-      tags: ['login'],
-    }
+    // const initiateLoginDocumentationPart = {
+    //   description: 'Initiates a login process for Turborepo.',
+    //   summary: 'Initiate login',
+    //   tags: ['login'],
+    // }
 
-    new apigateway.CfnDocumentationPart(this, 'TurborepoInitiateLoginDocumentationPart', {
-      location: {
-        type: 'METHOD',
-        method: 'GET',
-        path: '/v8/turborepo/token',
-      },
-      properties: JSON.stringify(initiateLoginDocumentationPart),
-      restApiId: api.restApiId,
-    });
+    // new apigateway.CfnDocumentationPart(this, 'TurborepoInitiateLoginDocumentationPart', {
+    //   location: {
+    //     type: 'METHOD',
+    //     method: 'GET',
+    //     path: '/v8/turborepo/token',
+    //   },
+    //   properties: JSON.stringify(initiateLoginDocumentationPart),
+    //   restApiId: api.restApiId,
+    // });
 
-    // GET /v8/turborepo/success
-    const successResource = turborepoResource.addResource('success');
-    successResource.addMethod('GET', new apigateway.LambdaIntegration(props.lambdaFunctions.loginSuccessFunction), {
-      operationName: 'loginSuccess',
-    });
+    // // GET /v8/turborepo/success
+    // const successResource = turborepoResource.addResource('success');
+    // successResource.addMethod('GET', new apigateway.LambdaIntegration(props.lambdaFunctions.loginSuccessFunction), {
+    //   operationName: 'loginSuccess',
+    // });
 
-    const loginSuccessDocumentationPart = {
-      description: 'Handles the success of a login process for Turborepo.',
-      summary: 'Login success',
-      tags: ['login'],
-    }
+    // const loginSuccessDocumentationPart = {
+    //   description: 'Handles the success of a login process for Turborepo.',
+    //   summary: 'Login success',
+    //   tags: ['login'],
+    // }
 
-    new apigateway.CfnDocumentationPart(this, 'TurborepoLoginSuccessDocumentationPart', {
-      location: {
-        type: 'METHOD',
-        method: 'GET',
-        path: '/v8/turborepo/success',
-      },
-      properties: JSON.stringify(loginSuccessDocumentationPart),
-      restApiId: api.restApiId,
-    });
+    // new apigateway.CfnDocumentationPart(this, 'TurborepoLoginSuccessDocumentationPart', {
+    //   location: {
+    //     type: 'METHOD',
+    //     method: 'GET',
+    //     path: '/v8/turborepo/success',
+    //   },
+    //   properties: JSON.stringify(loginSuccessDocumentationPart),
+    //   restApiId: api.restApiId,
+    // });
 
-    const v2Resource = api.root.addResource('v2');
+    // const v2Resource = api.root.addResource('v2');
 
-    const userResource = v2Resource.addResource('user');
+    // const userResource = v2Resource.addResource('user');
 
-    // GET /v2/user
-    userResource.addMethod('GET', new apigateway.LambdaIntegration(props.lambdaFunctions.getUserInfoFunction), {
-      operationName: 'getUserInfo',
-    });
+    // // GET /v2/user
+    // userResource.addMethod('GET', new apigateway.LambdaIntegration(props.lambdaFunctions.getUserInfoFunction), {
+    //   operationName: 'getUserInfo',
+    // });
 
-    const getUserInfoDocumentationPart = {
-      description: 'Retrieves information about the authenticated user.',
-      summary: 'Get user info',
-      tags: ['login'],
-    }
+    // const getUserInfoDocumentationPart = {
+    //   description: 'Retrieves information about the authenticated user.',
+    //   summary: 'Get user info',
+    //   tags: ['login'],
+    // }
 
-    new apigateway.CfnDocumentationPart(this, 'TurborepoUserInfoDocumentationPart', {
-      location: {
-        type: 'METHOD',
-        method: 'GET',
-        path: '/v2/user',
-      },
-      properties: JSON.stringify(getUserInfoDocumentationPart),
-      restApiId: api.restApiId,
-    });
+    // new apigateway.CfnDocumentationPart(this, 'TurborepoUserInfoDocumentationPart', {
+    //   location: {
+    //     type: 'METHOD',
+    //     method: 'GET',
+    //     path: '/v2/user',
+    //   },
+    //   properties: JSON.stringify(getUserInfoDocumentationPart),
+    //   restApiId: api.restApiId,
+    // });
 
     // cloudfront domain name for CNAME
     new cdk.CfnOutput(this, 'CloudfrontAliasDomainName', {

--- a/packages/construct/src/lambda.ts
+++ b/packages/construct/src/lambda.ts
@@ -16,6 +16,7 @@ export class LambdaFunctions extends Construct {
   public initiateLoginFunction: lambda.Function;
   public loginSuccessFunction: lambda.Function;
   public getUserInfoFunction: lambda.Function;
+  public readonly tokenAuthorizerFunction: lambda.Function;
 
   constructor(scope: Construct, id: string, props: LambdaFunctionsProps) {
     super(scope, id);
@@ -47,6 +48,16 @@ export class LambdaFunctions extends Construct {
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/dist/status')),
       environment: {
         BUCKET_NAME: props.artifactsBucket.bucketName,
+      },
+    });
+
+    this.tokenAuthorizerFunction = new lambda.Function(this, 'TokenAuthorizerFunction', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      functionName: 'turbo-remote-cache-token-authorizer',
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/dist/token-authorizer')),
+      environment: {
+        TURBO_TOKEN: process.env.TURBO_TOKEN!,
       },
     });
 

--- a/packages/construct/src/lambda.ts
+++ b/packages/construct/src/lambda.ts
@@ -51,32 +51,33 @@ export class LambdaFunctions extends Construct {
     });
 
     // turbo login
-    this.initiateLoginFunction = new lambda.Function(this, 'InitiateLoginFunction', {
-      runtime: lambda.Runtime.NODEJS_20_X,
-      functionName: 'turbo-remote-cache-initiate-login',
-      handler: 'index.handler',
-      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/dist/initiate-login')),
-      environment: {
-        TURBO_TOKEN: process.env.TURBO_TOKEN!,
-      },
-    });
+    // TODO: implement lambda authorizer to validate third party JWT
+    // this.initiateLoginFunction = new lambda.Function(this, 'InitiateLoginFunction', {
+    //   runtime: lambda.Runtime.NODEJS_20_X,
+    //   functionName: 'turbo-remote-cache-initiate-login',
+    //   handler: 'index.handler',
+    //   code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/dist/initiate-login')),
+    //   environment: {
+    //     TURBO_TOKEN: process.env.TURBO_TOKEN!,
+    //   },
+    // });
 
-    this.loginSuccessFunction = new lambda.Function(this, 'LoginSuccessFunction', {
-      runtime: lambda.Runtime.NODEJS_20_X,
-      functionName: 'turbo-remote-cache-login-success',
-      handler: 'index.handler',
-      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/dist/login-success')),
-      environment: {
-        TURBO_TOKEN: process.env.TURBO_TOKEN!,
-      },
-    });
+    // this.loginSuccessFunction = new lambda.Function(this, 'LoginSuccessFunction', {
+    //   runtime: lambda.Runtime.NODEJS_20_X,
+    //   functionName: 'turbo-remote-cache-login-success',
+    //   handler: 'index.handler',
+    //   code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/dist/login-success')),
+    //   environment: {
+    //     TURBO_TOKEN: process.env.TURBO_TOKEN!,
+    //   },
+    // });
 
-    this.getUserInfoFunction = new lambda.Function(this, 'GetUserInfoFunction', {
-      runtime: lambda.Runtime.NODEJS_20_X,
-      functionName: 'turbo-remote-cache-get-user-info',
-      handler: 'index.handler',
-      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/dist/get-user-info')),
-    });
+    // this.getUserInfoFunction = new lambda.Function(this, 'GetUserInfoFunction', {
+    //   runtime: lambda.Runtime.NODEJS_20_X,
+    //   functionName: 'turbo-remote-cache-get-user-info',
+    //   handler: 'index.handler',
+    //   code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/dist/get-user-info')),
+    // });
 
     props.artifactsBucket.grantRead(this.artifactQueryFunction);
     props.artifactsBucket.grantReadWrite(this.recordEventsFunction);

--- a/packages/construct/test/turbo-remote-cache.test.ts
+++ b/packages/construct/test/turbo-remote-cache.test.ts
@@ -35,7 +35,7 @@ describe('TurboRemoteCache Default Construct', () => {
   });
 
   test('Lambda Functions Created', () => {
-    template.resourceCountIs('AWS::Lambda::Function', 6);
+    template.resourceCountIs('AWS::Lambda::Function', 4);
   });
 
   test('S3 Bucket Lifecycle Rule', () => {


### PR DESCRIPTION
- add token authorizer for all methods in api gateway
- disable `turbo login` related methods for now. will be addressed in #13 
- update tests