### PR TITLE
🗃️ artifacts: update response headers and s3 location

### DIFF
--- a/packages/construct/src/get-artifact.ts
+++ b/packages/construct/src/get-artifact.ts
@@ -26,6 +26,7 @@ export function getArtifactIntegration(scope: Construct, props: GetArtifactInteg
             'method.response.header.ETag': 'integration.response.header.ETag',
             'method.response.header.Last-Modified': 'integration.response.header.Last-Modified',
             'method.response.header.x-artifact-duration': 'integration.response.header.x-amz-meta-artifact-duration',
+            'method.response.header.x-artifact-tag': 'integration.response.header.x-amz-meta-artifact-tag',
           },
           contentHandling: apigateway.ContentHandling.CONVERT_TO_BINARY,
         },
@@ -72,6 +73,7 @@ export function getArtifactIntegration(scope: Construct, props: GetArtifactInteg
           'method.response.header.ETag': true,
           'method.response.header.Last-Modified': true,
           'method.response.header.x-artifact-duration': true,
+          'method.response.header.x-artifact-tag': true,
         },
       },
       {

--- a/packages/construct/src/get-artifact.ts
+++ b/packages/construct/src/get-artifact.ts
@@ -14,7 +14,7 @@ export function getArtifactIntegration(scope: Construct, props: GetArtifactInteg
   const getIntegration = new apigateway.AwsIntegration({
     service: 's3',
     integrationHttpMethod: 'GET',
-    path: `${props.artifactsBucket.bucketName}/artifacts/{hash}`,
+    path: `${props.artifactsBucket.bucketName}/{slug}/{hash}`,
     options: {
       credentialsRole: props.s3Credentials,
       integrationResponses: [
@@ -48,6 +48,7 @@ export function getArtifactIntegration(scope: Construct, props: GetArtifactInteg
       ],
       requestParameters: {
         'integration.request.path.hash': 'method.request.path.hash',
+        'integration.request.path.slug': 'method.request.querystring.slug',
       },
     },
   });
@@ -56,6 +57,7 @@ export function getArtifactIntegration(scope: Construct, props: GetArtifactInteg
     operationName: 'downloadArtifact',
     requestParameters: {
       'method.request.path.hash': true,
+      'method.request.querystring.slug': true,
     },
     methodResponses: [
       {

--- a/packages/construct/src/get-artifact.ts
+++ b/packages/construct/src/get-artifact.ts
@@ -22,6 +22,10 @@ export function getArtifactIntegration(scope: Construct, props: GetArtifactInteg
           statusCode: '200',
           responseParameters: {
             'method.response.header.Content-Type': 'integration.response.header.Content-Type',
+            'method.response.header.Content-Length': 'integration.response.header.Content-Length',
+            'method.response.header.ETag': 'integration.response.header.ETag',
+            'method.response.header.Last-Modified': 'integration.response.header.Last-Modified',
+            'method.response.header.x-artifact-duration': 'integration.response.header.x-amz-meta-artifact-duration',
           },
           contentHandling: apigateway.ContentHandling.CONVERT_TO_BINARY,
         },
@@ -64,6 +68,10 @@ export function getArtifactIntegration(scope: Construct, props: GetArtifactInteg
         statusCode: '200',
         responseParameters: {
           'method.response.header.Content-Type': true,
+          'method.response.header.Content-Length': true,
+          'method.response.header.ETag': true,
+          'method.response.header.Last-Modified': true,
+          'method.response.header.x-artifact-duration': true,
         },
       },
       {

--- a/packages/construct/src/head-artifact.ts
+++ b/packages/construct/src/head-artifact.ts
@@ -14,7 +14,7 @@ export function headArtifactIntegration(scope: Construct, props: HeadArtifactInt
   const headIntegration = new apigateway.AwsIntegration({
     service: 's3',
     integrationHttpMethod: 'HEAD',
-    path: `${props.artifactsBucket.bucketName}/artifacts/{hash}`,
+    path: `${props.artifactsBucket.bucketName}/{slug}/{hash}`,
     options: {
       credentialsRole: props.s3Credentials,
       integrationResponses: [
@@ -34,6 +34,7 @@ export function headArtifactIntegration(scope: Construct, props: HeadArtifactInt
       ],
       requestParameters: {
         'integration.request.path.hash': 'method.request.path.hash',
+        'integration.request.path.slug': 'method.request.querystring.slug',
       },
     },
   });
@@ -42,6 +43,7 @@ export function headArtifactIntegration(scope: Construct, props: HeadArtifactInt
     operationName: 'artifactExists',
     requestParameters: {
       'method.request.path.hash': true,
+      'method.request.querystring.slug': true,
     },
     methodResponses: [
       {

--- a/packages/construct/src/head-artifact.ts
+++ b/packages/construct/src/head-artifact.ts
@@ -25,6 +25,7 @@ export function headArtifactIntegration(scope: Construct, props: HeadArtifactInt
             'method.response.header.Content-Type': 'integration.response.header.Content-Type',
             'method.response.header.ETag': 'integration.response.header.ETag',
             'method.response.header.Last-Modified': 'integration.response.header.Last-Modified',
+            'method.response.header.x-artifact-duration': 'integration.response.header.x-amz-meta-artifact-duration',
           },
         },
         {
@@ -49,6 +50,7 @@ export function headArtifactIntegration(scope: Construct, props: HeadArtifactInt
       {
         statusCode: '200',
         responseParameters: {
+          'method.response.header.x-artifact-duration': true,
           'method.response.header.Content-Length': true,
           'method.response.header.Content-Type': true,
           'method.response.header.ETag': true,

--- a/packages/construct/src/head-artifact.ts
+++ b/packages/construct/src/head-artifact.ts
@@ -26,6 +26,7 @@ export function headArtifactIntegration(scope: Construct, props: HeadArtifactInt
             'method.response.header.ETag': 'integration.response.header.ETag',
             'method.response.header.Last-Modified': 'integration.response.header.Last-Modified',
             'method.response.header.x-artifact-duration': 'integration.response.header.x-amz-meta-artifact-duration',
+            'method.response.header.x-artifact-tag': 'integration.response.header.x-amz-meta-artifact-tag',
           },
         },
         {
@@ -51,6 +52,7 @@ export function headArtifactIntegration(scope: Construct, props: HeadArtifactInt
         statusCode: '200',
         responseParameters: {
           'method.response.header.x-artifact-duration': true,
+          'method.response.header.x-artifact-tag': true,
           'method.response.header.Content-Length': true,
           'method.response.header.Content-Type': true,
           'method.response.header.ETag': true,

--- a/packages/construct/src/lambda.ts
+++ b/packages/construct/src/lambda.ts
@@ -12,17 +12,17 @@ interface LambdaFunctionsProps {
 export class LambdaFunctions extends Construct {
   public readonly recordEventsFunction: lambda.Function;
   public readonly artifactQueryFunction: lambda.Function;
-  public statusFunction: lambda.Function;
-  public initiateLoginFunction: lambda.Function;
-  public loginSuccessFunction: lambda.Function;
-  public getUserInfoFunction: lambda.Function;
+  public readonly statusFunction: lambda.Function;
+  public readonly initiateLoginFunction: lambda.Function;
+  public readonly loginSuccessFunction: lambda.Function;
+  public readonly getUserInfoFunction: lambda.Function;
   public readonly tokenAuthorizerFunction: lambda.Function;
 
   constructor(scope: Construct, id: string, props: LambdaFunctionsProps) {
     super(scope, id);
 
     this.recordEventsFunction = new lambda.Function(this, 'RecordEventsFunction', {
-      runtime: lambda.Runtime.NODEJS_18_X,
+      runtime: lambda.Runtime.NODEJS_20_X,
       functionName: 'turbo-remote-cache-record-events',
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/dist/record-events')),
@@ -32,7 +32,7 @@ export class LambdaFunctions extends Construct {
     });
 
     this.artifactQueryFunction = new lambda.Function(this, 'ArtifactQueryFunction', {
-      runtime: lambda.Runtime.NODEJS_18_X,
+      runtime: lambda.Runtime.NODEJS_20_X,
       functionName: 'turbo-remote-cache-artifact-query',
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/dist/artifact-query')),

--- a/packages/construct/src/put-artifact.ts
+++ b/packages/construct/src/put-artifact.ts
@@ -14,7 +14,8 @@ export function putArtifactIntegration(scope: Construct, props: PutArtifactInteg
   const putIntegration = new apigateway.AwsIntegration({
     service: 's3',
     integrationHttpMethod: 'PUT',
-    path: `${props.artifactsBucket.bucketName}/artifacts/{hash}`,
+    // path: `${props.artifactsBucket.bucketName}/{teamId}/{slug}/{hash}`,
+    path: `${props.artifactsBucket.bucketName}/{slug}/{hash}`,
     options: {
       credentialsRole: props.s3Credentials,
       integrationResponses: [
@@ -23,7 +24,7 @@ export function putArtifactIntegration(scope: Construct, props: PutArtifactInteg
           responseTemplates: {
             'application/json': JSON.stringify({
               urls: [
-                "https://$util.escapeJavaScript($context.domainName)/artifacts/$input.params('hash')"
+                "https://$util.escapeJavaScript($context.domainName)/$input.params('slug')/$input.params('hash')"
               ]
             }),
           },
@@ -41,6 +42,8 @@ export function putArtifactIntegration(scope: Construct, props: PutArtifactInteg
       ],
       requestParameters: {
         'integration.request.path.hash': 'method.request.path.hash',
+        // 'integration.request.path.teamId': 'method.request.querystring.teamId',
+        'integration.request.path.slug': 'method.request.querystring.slug',
         'integration.request.header.Content-Length': 'method.request.header.Content-Length',
         'integration.request.header.x-amz-meta-artifact-duration': 'method.request.header.x-artifact-duration',
         'integration.request.header.x-amz-meta-artifact-client-ci': 'method.request.header.x-artifact-client-ci',
@@ -54,6 +57,8 @@ export function putArtifactIntegration(scope: Construct, props: PutArtifactInteg
     operationName: 'uploadArtifact',
     requestParameters: {
       'method.request.path.hash': true,
+      // 'method.request.querystring.teamId': true,
+      'method.request.querystring.slug': true,
       'method.request.header.Content-Length': true,
       'method.request.header.x-artifact-duration': false,
       'method.request.header.x-artifact-client-ci': false,


### PR DESCRIPTION
- store artifacts in team slug prefix in s3
- fix analytics by returning `x-artifact-duration` in headers for GET and HEAD
- allow signing artifacts by returning `x-artifact-tag` in headers for GET and HEAD
- use node 20 for all lambda functions